### PR TITLE
Width and height shorthand, display select

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,6 +21,14 @@ Specify width and height of the window:
 ```
 crystalclock.exe -width 1920 -height 1080
 ```
+Specify which display the program should appear on:
+```
+crystalclock.exe -width 1920 -height 1080 -display 1
+```
+Shorter form:
+```
+crystalclock.exe -w 1920 -h 1080 -d 1
+```
 Additional flags:
 ```
 -fullscreen -borderless -undecorated

--- a/cmdparser.cpp
+++ b/cmdparser.cpp
@@ -16,8 +16,11 @@ map<string, CMDParameter> argsMap = {
 	{ CMD_WIDTH,  { WIDTH,  true }},
 	{ CMD_HEIGHT, { HEIGHT, true }},
 
-	{ CMD_SHORT_WIDTH,  { WIDTH,  true }},
-	{ CMD_SHORT_HEIGHT, { HEIGHT, true }},
+	{ CMD_WIDTH_SHORT, {WIDTH, true}},
+	{ CMD_HEIGHT_SHORT, {HEIGHT, true}},
+
+	{ CMD_DISPLAY, {DISPLAY, true} },
+	{ CMD_DISPLAY_SHORT, {DISPLAY, true} },
 
 	{ CMD_BORDERLESS,  { BORDERLESS,  false }},
 	{ CMD_FULLSCREEN,  { FULLSCREEN,  false }},
@@ -38,6 +41,7 @@ int ParseInt(const string& cmd)
 
 bool ParseCMD(Config& config, int argc, char** argv, string& err)
 {
+	// prog.exe -width 1920 -height 1080
 	if (argc < 5)
 	{
 		err = "Not enough arguments";
@@ -94,6 +98,18 @@ bool ParseCMD(Config& config, int argc, char** argv, string& err)
 				}
 				config.screenHeight = height;
 				hasHeight = true;
+			}
+			break;
+
+			case DISPLAY:
+			{
+				int display = ParseInt(currCmd);
+				if (display < 0)
+				{
+					err = "Invalud value passed to: " + lastCmd;
+					return false;
+				}
+				config.display = display;
 			}
 			break;
 		}

--- a/cmdparser.h
+++ b/cmdparser.h
@@ -6,8 +6,11 @@
 constexpr auto CMD_WIDTH  = "-width";
 constexpr auto CMD_HEIGHT = "-height";
 
-constexpr auto CMD_SHORT_WIDTH  = "-w";
-constexpr auto CMD_SHORT_HEIGHT = "-h";
+constexpr auto CMD_WIDTH_SHORT = "-w";
+constexpr auto CMD_HEIGHT_SHORT = "-h";
+
+constexpr auto CMD_DISPLAY = "-display";
+constexpr auto CMD_DISPLAY_SHORT = "-d";
 
 constexpr auto CMD_BORDERLESS  = "-borderless";
 constexpr auto CMD_FULLSCREEN  = "-fullscreen";
@@ -17,6 +20,9 @@ struct Config
 {
 	int screenWidth;
 	int screenHeight;
+
+	int display;
+
 	int flags;
 };
 
@@ -27,7 +33,9 @@ enum Argument
 
 	BORDERLESS,
 	FULLSCREEN,
-	UNDECORATED
+	UNDECORATED,
+
+	DISPLAY
 };
 
 struct CMDParameter

--- a/crystalclock.cpp
+++ b/crystalclock.cpp
@@ -12,6 +12,9 @@ using namespace std;
 int screenWidth  = 1920;
 int screenHeight = 1080;
 
+int display = 0;
+int displayCount = 0;
+
 const Vector3 PRISM_COLORS[] = {
     { 0.04, 0.23, 0.46 },
     { 0.17, 0.03, 0.45 },
@@ -251,6 +254,8 @@ int main(int argc, char** argv)
     screenWidth  = cfg.screenWidth;
     screenHeight = cfg.screenHeight;
 
+    display = cfg.display;
+
     //------------------------------------------------------------------------------------
     // Retrieve time locale
     //------------------------------------------------------------------------------------
@@ -259,11 +264,29 @@ int main(int argc, char** argv)
     const char* timeLocale = setlocale(LC_TIME, nullptr);
 
     //------------------------------------------------------------------------------------
-    // Camaera/window initialization
+    // Camera/window initialization
     //------------------------------------------------------------------------------------
 
     SetConfigFlags(cfg.flags);
     InitWindow(screenWidth, screenHeight, "PS2 Clock");
+
+    //------------------------------------------------------------------------------------
+    // Retrieve display count
+    //------------------------------------------------------------------------------------
+
+    displayCount = GetMonitorCount();
+
+    //------------------------------------------------------------------------------------
+    // Attempting to move window to specified display
+    //------------------------------------------------------------------------------------
+    if(display < displayCount && display >-1)
+    {
+        SetWindowMonitor(display);
+    }
+    else
+    {
+        SetWindowMonitor(0);
+    }
 
     camera = { 0 };
     InitCamera();


### PR DESCRIPTION
This pr adds the options to
- use shorted params for width and height (`-w`, `-h`)
- option to choose which display the program will appear on (`-display` or `-d`, indexed from 0)