### PR TITLE
Fixed compile error

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <fstream>
+#include <algorithm>
 
 using namespace std;
 


### PR DESCRIPTION
The desktop C++ version refused to compile with an error,
stating that `find_if` wasn't part of the `std` namespace.
Only one line was added, at the beginning: `#include <algorithm>`